### PR TITLE
chore: bump action runtime to node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - run: npm ci
       - run: npm test
 

--- a/action.yaml
+++ b/action.yaml
@@ -26,5 +26,5 @@ outputs:
   version:
     description: 'Generated version number'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "typescript": "^5.3.3"
             },
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=24.0.0"
             }
         },
         "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "GitHub Action for Calendar Versioning",
     "main": "dist/index.js",
     "scripts": {
-        "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --minify --outfile=dist/index.js",
+        "build": "esbuild src/index.ts --bundle --platform=node --target=node24 --minify --outfile=dist/index.js",
         "test": "jest --coverage=false",
         "test:coverage": "jest --coverage",
         "lint": "eslint .",
@@ -56,6 +56,6 @@
         "typescript": "^5.3.3"
     },
     "engines": {
-        "node": ">=20.0.0"
+        "node": ">=24.0.0"
     }
 }


### PR DESCRIPTION
## Summary
- Update `action.yaml` to `runs.using: node24`
- Update esbuild target and `engines.node` to node24
- Bump CI `setup-node` to 24

## Test plan
- [x] `npm test` passes locally (49 tests)
- [x] `npm run build` produces `dist/index.js`
- [x] CI green
- [ ] After merge: tag `v2` to signal new runtime (keeping `v1` pinned to node20 for existing users)

Closes #2